### PR TITLE
Allow to override driud archive filename

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,7 @@ default[:druid][:group] = "druid"
 default[:druid][:install_dir] = "/opt/druid"
 default[:druid][:config_dir] = "/etc/druid"
 default[:druid][:data_dirs] = []
+default[:druid][:druid_dir_prefix] = "druid-services"
 
 # Configuration defaults
 default[:druid][:log_to_syslog] = 1

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -26,7 +26,7 @@ action :install do
 
 
   # Download and extract
-  druid_dir = "druid-services-#{node[:druid][:version]}"
+  druid_dir = "#{node[:druid][:druid_dir_prefix]}-#{node[:druid][:version]}"
   druid_archive = "#{druid_dir}-bin.tar.gz"
   remote_file ::File.join(Chef::Config[:file_cache_path], druid_archive) do
     Chef::Log.info("Installing file '#{druid_archive}' from site '#{node[:druid][:mirror]}'")


### PR DESCRIPTION
it's necessary to change archive filename to upgrade to next druid version